### PR TITLE
詳細ページ内のTopPageリンク作成

### DIFF
--- a/app/assets/stylesheets/results.css
+++ b/app/assets/stylesheets/results.css
@@ -684,3 +684,9 @@ span{
 .group-name-list{
   margin: 3vh 0;
 }
+
+.top-page-link-show{
+  font-size: auto;
+  text-align: center;
+  margin: 5vh;
+}

--- a/app/views/travels/show.html.erb
+++ b/app/views/travels/show.html.erb
@@ -73,3 +73,7 @@
     <p>
   <% end %>
 <div>
+
+<div class='top-page-link-show'>
+  <%= link_to 'トップページへ戻る', root_path %>
+</div>


### PR DESCRIPTION
#What
詳細ページ内のTopPageリンク作成
#Why
詳細ページからTopPageに遷移するためのリンクを設け、利便性を向上させるため
(AWS設定の前に気になった為実施…。)